### PR TITLE
Fix #24: Dashboard: subscription usage tracking for Claude Max and Codex

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,6 @@ const celebrations = [];
 const celebrationByKey = new Map();
 let soundEnabled = false;
 let audioCtx = null;
-let usageData = null;
 let usageLastFetch = 0;
 
 // === DRAWING HELPERS ===
@@ -953,6 +952,10 @@ function formatUsageValue(value) {
 
 function formatUsageRange(metric) {
   if (!metric) return '—';
+  // Anthropic format: utilization is a percentage directly
+  if (metric.utilization !== null && metric.utilization !== undefined) {
+    return `${Number(metric.utilization).toFixed(1)}%`;
+  }
   const used = formatUsageValue(metric.used);
   const limit = formatUsageValue(metric.limit);
   const unit = metric.unit ? ` ${metric.unit}` : '';
@@ -969,7 +972,12 @@ function formatUsageRange(metric) {
 }
 
 function usagePercent(metric) {
-  if (!metric || metric.used === null || metric.used === undefined) return null;
+  if (!metric) return null;
+  // Anthropic format: utilization is already a percentage (0-100)
+  if (metric.utilization !== null && metric.utilization !== undefined) {
+    return clamp(Number(metric.utilization) / 100, 0, 1);
+  }
+  if (metric.used === null || metric.used === undefined) return null;
   if (metric.limit === null || metric.limit === undefined || metric.limit === 0) return null;
   return clamp(metric.used / metric.limit, 0, 1);
 }

--- a/server.js
+++ b/server.js
@@ -615,26 +615,18 @@ async function getClaudeUsage() {
         if (data.five_hour || data.seven_day) {
           const metrics = [];
           if (data.five_hour) {
-            const utilization = Number(data.five_hour.utilization);
-            const percent = Number.isFinite(utilization) ? Math.round(utilization * 100) : 0;
             metrics.push({
               id: 'five_hour',
               label: '5h window',
-              used: percent,
-              limit: 100,
-              unit: '%',
+              utilization: Number(data.five_hour.utilization) || 0,
               resetAt: data.five_hour.resets_at || null,
             });
           }
           if (data.seven_day) {
-            const utilization = Number(data.seven_day.utilization);
-            const percent = Number.isFinite(utilization) ? Math.round(utilization * 100) : 0;
             metrics.push({
               id: 'seven_day',
               label: '7d window',
-              used: percent,
-              limit: 100,
-              unit: '%',
+              utilization: Number(data.seven_day.utilization) || 0,
               resetAt: data.seven_day.resets_at || null,
             });
           }


### PR DESCRIPTION
## Summary
- **Server**: New `/api/usage` endpoint that runs `claude-usage-report.sh --json` and caches results for 5 minutes. Parses the Anthropic OAuth usage API format (`five_hour`/`seven_day` utilization windows) natively, with fallback generic parser for other formats.
- **Server**: Codex usage estimated from active agent token counts via existing JSONL parsing.
- **Frontend (canvas)**: New usage panel between timeline and status bar showing Claude 5h/7d utilization bars, extra usage, and Codex token summary.
- **Frontend (HTML)**: DOM-based usage cards with provider details, progress bars, reset times, and status pills.
- **Warnings**: Color-coded bars (green < 80%, yellow 80-95%, red > 95%) with blinking "LIMIT!" or "WARN" indicators.
- **Demo mode**: Includes mock usage data so the panel is visible without a live server.

## Test plan
- [ ] Run `node server.js` and verify `/api/usage` returns usage data
- [ ] Open the dashboard and verify the usage panel renders below the timeline
- [ ] Click "Demo Mode" and verify the mock usage panel displays correctly
- [ ] Verify warning colors change at 80% and 95% thresholds

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)