### PR TITLE
Fix #65: SV UI: canvas/dashboard missing on mobile portrait view

### DIFF
--- a/sv.html
+++ b/sv.html
@@ -457,17 +457,23 @@
     .sb-section { padding: 12px 14px; }
     .sb-header { font-size: 10px; margin-bottom: 12px; }
 
-    /* Scene area: responsive */
+    /* Scene area: responsive — fill width, auto height from aspect ratio */
     .scene-wrap {
       flex: none;
       width: 100%;
+      min-height: 200px;
     }
     .canvas-area {
       width: 100%;
-      aspect-ratio: 640 / 384;
-      min-height: 0;
+      height: 0;
+      padding-bottom: 60%; /* 384/640 = 60% aspect ratio */
+      position: relative;
+      overflow: hidden;
     }
     .canvas-area canvas {
+      position: absolute;
+      top: 0;
+      left: 0;
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
## Summary
- Replace CSS `aspect-ratio` with `padding-bottom: 60%` trick on `.canvas-area` so it doesn't collapse to zero height in a flex column layout on mobile portrait
- Add `min-height: 200px` on `.scene-wrap` as a safety net
- Position the canvas absolutely inside `.canvas-area` to fill the padding-based container

## Test plan
- [ ] Open sv.html on iPhone-sized viewport (375px wide, portrait) — canvas is visible
- [ ] Canvas maintains correct 640:384 aspect ratio
- [ ] Desktop layout unchanged
- [ ] Landscape mobile still works

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)