### PR TITLE
Fix #67: SV mobile: stack sidebar below canvas instead of overlay

### DIFF
--- a/sv.html
+++ b/sv.html
@@ -388,7 +388,8 @@
       min-height: 100vh;
     }
 
-    .mobile-menu-btn { display: inline-block; }
+    .mobile-menu-btn { display: none; }
+    .mobile-overlay { display: none !important; }
 
     /* Top bar: wrap stats to next line */
     .top-bar {
@@ -416,27 +417,19 @@
       min-height: calc(100vh - 70px);
     }
 
-    /* Sidebar: collapsible overlay on mobile */
+    /* Sidebar: stacked below canvas on mobile */
     .sidebar {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 85vw;
-      max-width: 360px;
+      position: static;
+      width: 100%;
+      max-width: none;
       min-width: 0;
-      height: 100vh;
-      z-index: 50;
-      transform: translateX(-100%);
-      transition: transform 0.25s ease;
-      border-right: 3px solid #f0c040;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
-    }
-    .sidebar.mobile-open {
-      transform: translateX(0);
-    }
-    .mobile-overlay.visible {
-      display: block;
+      height: auto;
+      z-index: auto;
+      transform: none;
+      transition: none;
+      border-right: none;
+      border-top: 2px solid #f0c040;
+      overflow-y: visible;
     }
 
     /* Hide desktop resize handle on mobile */
@@ -514,10 +507,6 @@
     .top-title .ver { font-size: 6px; }
     .top-stats { font-size: 6px; gap: 6px 10px; }
     .top-btn { font-size: 7px; padding: 2px 5px; }
-
-    .sidebar {
-      width: 90vw;
-    }
 
     .sb-header { font-size: 9px; }
     .agent-card { padding: 10px 12px; }


### PR DESCRIPTION
## Summary

- **Sidebar**: Changed from `position: fixed` overlay (hidden behind hamburger menu) to `position: static; width: 100%` so it flows inline below the canvas/status bar
- **Hamburger menu & overlay**: Hidden on mobile since sidebar content is always visible
- **Visual separation**: Added a `2px solid #f0c040` top border on the sidebar as a divider between canvas and sidebar content

## Layout (mobile portrait ≤767px)

```
┌─────────────┐
│  Top bar     │
│  Stats       │
├─────────────┤
│  Canvas      │  (padding-bottom: 60%)
├─────────────┤
│  Status bar  │
├─────────────┤
│  Agent cards │  ← sidebar content inline
│  Usage       │
│  Timeline    │
└─────────────┘
```

CSS-only change — no JS modifications. All existing touch-friendly sizing (tap-to-expand agent cards, larger padding) is preserved.

Fixes #67

## Test plan

- [ ] Open `sv.html` on mobile portrait (≤767px viewport)
- [ ] Verify sidebar content (agent cards, usage, timeline) appears below canvas
- [ ] Verify no hamburger menu button is visible
- [ ] Verify gold divider line separates canvas area from sidebar
- [ ] Verify desktop layout (≥768px) is unchanged (sidebar on left, resizable)
- [ ] Verify agent card tap-to-expand still works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)