### PR TITLE
Fix #105: SV mode: quest log links not working on mobile/iPhone

### DIFF
--- a/sv.html
+++ b/sv.html
@@ -310,13 +310,22 @@
     border-bottom: 1px solid #1a1a2e;
     font-size: 7px;
   }
+  a.ql-entry {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: rgba(136, 170, 255, 0.3);
+    touch-action: manipulation;
+    min-height: 44px;
+  }
+  a.ql-entry:hover { background: rgba(136, 170, 255, 0.08); }
+  a.ql-entry .ql-name { color: #88aaff; }
+  a.ql-entry:hover .ql-name { color: #aaccff; text-decoration: underline; }
   .ql-entry:last-child { border-bottom: none; }
   .ql-icon { flex-shrink: 0; font-size: 9px; line-height: 1; }
   .ql-body { flex: 1; min-width: 0; }
   .ql-head { display: flex; align-items: baseline; gap: 4px; }
   .ql-name { color: #ccc; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .ql-link { color: #88aaff; text-decoration: none; cursor: pointer; }
-  .ql-link:hover { color: #aaccff; text-decoration: underline; }
   .ql-status { white-space: nowrap; font-size: 6px; }
   .ql-time { flex-shrink: 0; color: #555; font-size: 6px; margin-left: auto; }
   .ql-title { color: #666; font-size: 6px; margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -666,7 +675,7 @@
 
     /* Quest Log feed: slightly larger on mobile */
     .ql-feed { max-height: 240px; }
-    .ql-entry { font-size: 8px; gap: 8px; padding: 5px 0; }
+    .ql-entry { font-size: 8px; gap: 8px; padding: 5px 0; min-height: 44px; }
     .ql-status { font-size: 7px; }
     .ql-time { font-size: 7px; }
     .ql-title { font-size: 7px; }
@@ -1445,21 +1454,20 @@ function renderTimeline() {
       ? `<div class="ql-title">${escapeHtml(ev.title)}</div>`
       : '';
 
-    const nameHtml = ev.url
-      ? `<a href="${escapeHtml(ev.url)}" target="_blank" rel="noopener" class="ql-name ql-link">${escapeHtml(ev.name)}</a>`
-      : `<span class="ql-name">${escapeHtml(ev.name)}</span>`;
+    const tag = ev.url ? 'a' : 'div';
+    const linkAttrs = ev.url ? ` href="${escapeHtml(ev.url)}" target="_blank" rel="noopener"` : '';
 
-    return `<div class="ql-entry">
+    return `<${tag}${linkAttrs} class="ql-entry">
       <span class="ql-icon">${icon}</span>
       <div class="ql-body">
         <div class="ql-head">
-          ${nameHtml}
+          <span class="ql-name">${escapeHtml(ev.name)}</span>
           <span class="ql-status" style="color:${color}">${label}</span>
           <span class="ql-time">${timeAgo}</span>
         </div>
         ${titleLine}
       </div>
-    </div>`;
+    </${tag}>`;
   });
 
   container.innerHTML = rows.join('');


### PR DESCRIPTION
## Summary
- Made the entire quest log row (`ql-entry`) an `<a>` element when a URL exists, instead of just the tiny name text
- Added 44px minimum touch target height for mobile (Apple HIG compliant)
- Added `-webkit-tap-highlight-color` and `touch-action: manipulation` for proper iOS tap behavior
- Added subtle hover highlight on desktop
- Entries without a URL remain `<div>` elements (not clickable)

## Changes
- `sv.html`: CSS — added `a.ql-entry` styles (tap highlight, min-height, hover state)
- `sv.html`: CSS mobile — added `min-height: 44px` to `.ql-entry` at mobile breakpoint
- `sv.html`: JS `renderTimeline()` — row is `<a>` with href when URL exists, `<div>` otherwise

## Test Results

### Issue Test Criteria
- [x] Tapping a quest log entry on iPhone opens the PR/issue in Safari — entire row is now an `<a>` with `target="_blank"`, tap highlight visible
- [x] Entire row is tappable (not just the small name text) — row uses `<a class="ql-entry">` wrapping icon + body
- [x] Touch target is at least 44px tall — `min-height: 44px` set on `a.ql-entry` and mobile `.ql-entry`
- [x] Hover shows subtle highlight on desktop — `a.ql-entry:hover` has `background: rgba(136, 170, 255, 0.08)`
- [x] Links open in new tab — `target="_blank" rel="noopener"` on all link rows
- [x] Entries without a URL (no repo/PR) are not clickable — rendered as `<div>` not `<a>`
- [x] Screenshots showing clickable entries — attached below

### Standard Checks
- [x] Server starts without errors
- [x] Both pages load (canvas element present)
- [x] No JS syntax errors (`sv.html JS OK`, `index.html JS OK`)
- [x] Screenshots attached

## Screenshots

### Desktop (1280×800)
![Desktop](screenshot-desktop.png)

### Mobile (375×812)
![Mobile](screenshot-mobile.png)

Fixes #105