### PR TITLE
Fix #125: Quest log URLs missing owner — generates invalid GitHub links

### DIFF
--- a/sv.html
+++ b/sv.html
@@ -1423,6 +1423,7 @@ function renderTimeline() {
     if (!eventTime) eventTime = getCreatedAt(item) || now;
 
     const repoName = getRepoName(item);
+    const fullRepo = item.repo || item.repository || '';
     const issueId = getIssueId(item);
     const name = repoName && issueId ? repoName + '#' + issueId : (repoName || escapeHtml((item.id || '').substring(0, 12)));
     const title = item.issueTitle || item.issue_title || '';
@@ -1432,8 +1433,8 @@ function renderTimeline() {
     const prNum = getPrNumber(item);
     let url = '';
     if (prUrl) url = prUrl;
-    else if (repoName && prNum) url = 'https://github.com/' + repoName + '/pull/' + prNum;
-    else if (repoName && issueId) url = 'https://github.com/' + repoName + '/issues/' + issueId;
+    else if (fullRepo && prNum) url = 'https://github.com/' + fullRepo + '/pull/' + prNum;
+    else if (fullRepo && issueId) url = 'https://github.com/' + fullRepo + '/issues/' + issueId;
 
     return { state, eventTime, name, title, item, url };
   });


### PR DESCRIPTION
## Summary
- Quest log URL builder used `getRepoName()` which strips the owner (`.split('/').pop()`), producing invalid links like `github.com/corral/pull/3`
- Now uses `item.repo` (full `owner/repo` path) for URL construction, generating correct links like `github.com/shenyuanv/corral/pull/3`
- Display labels (e.g. `corral#3`) still use the short `getRepoName()` — unchanged

## Test Results

### Issue Test Criteria
- [x] Quest log links include the full `owner/repo` path — URLs now built with `fullRepo` (`item.repo`) instead of `repoName`
- [x] Quest log display name still shows short repo name — `name` variable still uses `getRepoName()` on line 1428
- [x] Canvas click URLs (`getAgentUrl`) remain unaffected — `getAgentUrl()` already uses `agent.repo` directly (line 3583-3585), no changes made

### Standard Checks
- [x] Server starts without errors
- [x] Both pages load (canvas element present)
- [x] No JS syntax errors

## Test plan
- [ ] With real session data, verify quest log links navigate to valid GitHub URLs with owner prefix
- [ ] Verify quest log entry labels still show short `repo#issue` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)